### PR TITLE
removed unnecessary closing script tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ All this work is based on the following assumptions:
 
 #### HTML
 
-    <link rel="stylesheet" href="release/angular-responsive-tables.min.css"></script>
+    <link rel="stylesheet" href="release/angular-responsive-tables.min.css">
     <script type="text/javascript" src="release/angular-responsive-tables.min.js"></script>
 
 #### JavaScript


### PR DESCRIPTION
Hi I have removed closing "script" tag in the Application section of README for the css linking line.
